### PR TITLE
Lock modal scroll on <html> with stable scrollbar gutter

### DIFF
--- a/frontend/app/assets/css/tailwind.css
+++ b/frontend/app/assets/css/tailwind.css
@@ -720,9 +720,6 @@
    */
   :root,
   .dark {
-    /* The modal scroll lock temporarily replaces this computed value with the
-       measured gutter, keeping fixed corner controls in place as it animates. */
-    --scrollbar-gutter: calc(100vw - 100%);
     --background: #1d1d1d;
     --surface: #252526;
     --surface-hover: #2c2c2c;
@@ -835,6 +832,7 @@
    */
   html {
     overscroll-behavior-y: none;
+    scrollbar-gutter: stable;
   }
 
   html.dark {

--- a/frontend/app/components/common/FabDock.vue
+++ b/frontend/app/components/common/FabDock.vue
@@ -32,10 +32,8 @@ const isPlayerBarVisible = computed(() => showPlayer.value && !!currentResult.va
 </script>
 
 <template>
-  <!-- The gutter keeps the column still while a modal's scroll lock removes the
-       scrollbar underneath it. -->
   <div
-    class="fixed end-[calc(1.5rem+var(--scrollbar-gutter))] z-50 flex flex-col items-center gap-3 transition-[bottom] duration-300 ease-in-out"
+    class="fixed end-6 z-50 flex flex-col items-center gap-3 transition-[bottom] duration-300 ease-in-out"
     :class="isPlayerBarVisible ? 'bottom-40 md:bottom-24' : 'bottom-6'"
   >
     <!-- `contents` so an empty dock costs no height and no gap: a plain empty

--- a/frontend/app/composables/useModalState.ts
+++ b/frontend/app/composables/useModalState.ts
@@ -6,11 +6,11 @@
  * instead of probing the DOM. `BaseModal` is the only thing that should call
  * `registerModal`/`unregisterModal`.
  *
- * The stack doubles as the scroll-lock counter: the body is locked while at
- * least one modal is registered, so nested modals can't unlock each other.
+ * The stack doubles as the scroll-lock counter: the root scrolling element
+ * (`<html>`) is locked while at least one modal is registered, so nested
+ * modals can't unlock each other.
  */
-let savedBodyOverflow = '';
-let savedScrollbarGutter = '';
+let savedHtmlOverflow = '';
 
 export function useModalState() {
   const openModals = useState<string[]>('nd-open-modals', () => []);
@@ -21,24 +21,14 @@ export function useModalState() {
 
   const lockScroll = () => {
     if (!import.meta.client) return;
-    // Locking body removes a classic scrollbar. Keep its measured width in a
-    // CSS variable so fixed corner controls can retain their screen position
-    // for the full modal transition.
-    const scrollbarGutter = window.innerWidth - document.documentElement.clientWidth;
-    savedBodyOverflow = document.body.style.overflow;
-    savedScrollbarGutter = document.documentElement.style.getPropertyValue('--scrollbar-gutter');
-    document.documentElement.style.setProperty('--scrollbar-gutter', `${scrollbarGutter}px`);
-    document.body.style.overflow = 'hidden';
+    const root = document.documentElement;
+    savedHtmlOverflow = root.style.overflow;
+    root.style.overflow = 'hidden';
   };
 
   const unlockScroll = () => {
     if (!import.meta.client) return;
-    document.body.style.overflow = savedBodyOverflow;
-    if (savedScrollbarGutter) {
-      document.documentElement.style.setProperty('--scrollbar-gutter', savedScrollbarGutter);
-    } else {
-      document.documentElement.style.removeProperty('--scrollbar-gutter');
-    }
+    document.documentElement.style.overflow = savedHtmlOverflow;
   };
 
   const registerModal = (id: string) => {


### PR DESCRIPTION
## Description

Locking `document.body.style.overflow = 'hidden'` for the modal removed the scrollbar on Chromium-classic and shifted the layout by its width (~15 px). With `scrollbar-gutter: stable` on `<html>` and the lock moved to `document.documentElement`, the gutter is reserved either way and the document width never changes. The JS scrollbar-width measurement and the FabDock offset based on it are gone.

## Type of Change
<!-- Please check the relevant option(s) -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Changes Made
- `frontend/app/assets/css/tailwind.css`: add `scrollbar-gutter: stable;`
  on `html`; drop the now-unused `--scrollbar-gutter` token.
- `frontend/app/composables/useModalState.ts`: read/write
  `document.documentElement.style.overflow`; drop the scrollbar-width
  measurement and the inline custom-property writes on `<html>`; preserve
  and restore the pre-existing inline `overflow` on `<html>`. Modal-stack
  semantics and the SSR guard are unchanged.
- `frontend/app/components/common/FabDock.vue`: replace
  `end-[calc(1.5rem+var(--scrollbar-gutter))]` with plain `end-6`.

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] I have tested these changes locally
- [X] I ran `bun run check` (or documented why not)
<!-- Paste output snippets for lint/typecheck/build below -->
```text
<paste check output>
```
<!-- Also add screenshots to help explain your changes if necessary -->

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have checked for any breaking changes
- [ ] I confirmed whether this PR changes API/OpenAPI contracts
- [ ] I confirmed whether this PR requires a database migration

## Additional Notes
<!-- Any additional information or context for reviewers -->
撫子花开，页面不动摇