### PR TITLE
frontend: fold curly double quotes to straight before encoding the search query

### DIFF
--- a/frontend/app/components/search/base/InputSegment.vue
+++ b/frontend/app/components/search/base/InputSegment.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { mdiClose, mdiMagnify, mdiTextSearch } from '@mdi/js';
-import { decodeSearchQuery } from '~/utils/routes';
+import { decodeSearchQuery, normalizeSearchQuery } from '~/utils/routes';
 import { RECENTS_LISTBOX_ID, recentOptionId } from '~/utils/searchRecents';
 
 const props = withDefaults(
@@ -189,7 +189,10 @@ onClickOutside(searchBarRef, closeRecents);
  */
 const navigateSearchSentence = async (options: { scope?: string | null } = {}) => {
   const { query: _query, hideLangs: _, blurLangs: __, ...restOfQuery } = route.value.query;
-  const term = query.value?.trim();
+  // Curly double quotes fold to the straight form before the URL is built so an
+  // exact-phrase search matches the same lines as if the reader had typed them
+  // by hand. See `normalizeSearchQuery`.
+  const term = normalizeSearchQuery(query.value?.trim());
 
   let nextQuery: typeof restOfQuery = restOfQuery;
   if (options.scope !== undefined) {

--- a/frontend/app/utils/routes.test.ts
+++ b/frontend/app/utils/routes.test.ts
@@ -10,6 +10,7 @@ import {
   overEscapedSearchQuery,
   queryAndHash,
   mediaBrowsePath,
+  normalizeSearchQuery,
   searchScopeQuery,
   splitLocalePrefix,
   withLocalePrefix,
@@ -67,6 +68,52 @@ describe('decodeSearchQuery', () => {
   it.each(['%E8%AD', '%C0%80', '%25E8%AD%B2', '%'])('survives the malformed escape %s', (raw) => {
     expect(() => decodeSearchQuery(raw)).not.toThrow();
     expect(decodeSearchQuery(raw)).toBe(raw);
+  });
+});
+
+describe('normalizeSearchQuery', () => {
+  // Only the curly double quote (the typographic equivalent of `"`) is
+  // folded: it is what auto-correct and word processors substitute for the
+  // straight quote, and what the reader is using to mark an exact phrase.
+  // Other quote-shaped characters are deliberately left alone -- they are
+  // literal text the reader typed (often dialogue marks in a subtitle), not
+  // search syntax, and folding them to `"` would invent an exact-match
+  // intent the reader did not have.
+  it('folds both curly double quotes to the straight form', () => {
+    expect(normalizeSearchQuery('\u201C\u98df\u3079\u3089\u308c\u306a\u3044\u201D')).toBe(
+      '"\u98df\u3079\u3089\u308c\u306a\u3044"',
+    );
+    // Same Japanese phrase, one curly and one straight -- only the curly
+    // half is folded, which is enough to land on the straight-quoted corpus.
+    expect(normalizeSearchQuery('\u201C\u98df\u3079\u3089\u308c\u306a\u3044')).toBe(
+      '"\u98df\u3079\u3089\u308c\u306a\u3044',
+    );
+  });
+
+  it('leaves straight quotes alone', () => {
+    expect(normalizeSearchQuery('"\u98df\u3079\u3089\u308c\u306a\u3044"')).toBe(
+      '"\u98df\u3079\u3089\u308c\u306a\u3044"',
+    );
+  });
+
+  it.each([
+    // Curly single quotes -- literal text, not search syntax.
+    ['\u2018', '\u2019'],
+    // Low-9 / high-reversed variants -- literal text.
+    ['\u201A', '\u201B'],
+    ['\u201E', '\u201F'],
+    // French / Spanish / Russian angle quotes -- literal text.
+    ['\u00AB', '\u00BB'],
+    // CJK corner brackets -- dialogue marks in subtitles, not search syntax.
+    ['\u300C', '\u300D'],
+    ['\u300E', '\u300F'],
+  ])('leaves %s and %s alone (not search syntax)', (open, close) => {
+    const phrase = `${open}\u98df\u3079\u3089\u308c\u306a\u3044${close}`;
+    expect(normalizeSearchQuery(phrase)).toBe(phrase);
+  });
+
+  it('returns the empty string untouched', () => {
+    expect(normalizeSearchQuery('')).toBe('');
   });
 });
 

--- a/frontend/app/utils/routes.ts
+++ b/frontend/app/utils/routes.ts
@@ -36,6 +36,44 @@ export function buildScopedSearchPath(word: string, mediaPublicId?: string | nul
 }
 
 /**
+ * What the search box's typed text reads as when it reaches a URL.
+ *
+ * Lucene's `query_string` only treats U+0022 (straight double quote) as the
+ * phrase delimiter, so the curly-double variants `U+201C` / `U+201D` (the
+ * typographic characters auto-correct and word processors hand the reader)
+ * arrive as plain text and silently break an exact-phrase search. The
+ * reader's intent in both shapes is the same -- "this is a phrase" -- so
+ * fold them back to `"` before the URL is built and let the analyzer do
+ * the rest.
+ *
+ * SCOPE -- and why other quote-like characters are deliberately left
+ * alone:
+ *
+ *  - `U+201C` / `U+201D` (curly double): the typographic equivalent of
+ *    `"`. Folding them preserves the reader's intent to mark an exact
+ *    phrase, which is the bug the report is about.
+ *  - `U+2018` / `U+2019` (curly single), `U+201A` / `U+201B` and
+ *    `U+201E` / `U+201F` (low/high variants), `U+00AB` / `U+00BB`
+ *    (angle quotes), `U+300C` / `U+300D` and `U+300E` / `U+300F` (CJK
+ *    brackets): NOT folded. These are not search-syntax -- the reader
+ *    hasn't asked for an exact phrase, they've typed literal text that
+ *    happens to be wrapped in punctuation (often dialogue marks in a
+ *    subtitle). Folding them to `"` would invent an exact-match intent
+ *    the reader didn't have and would change the semantic of the query
+ *    from "find sentences containing this text" to "find this exact
+ *    phrase". The corpus tokenizer already treats them as punctuation
+ *    and the search works as the reader expects without any folding.
+ *
+ * If a future report names a quote character that the corpus tokenizer
+ * is mishandling, that is an analyzer fix, not an input-funnel fix -- and
+ * folding at the input side would hide the real corpus-vs-input mismatch
+ * that the analyzer change is meant to surface.
+ */
+export function normalizeSearchQuery(raw: string): string {
+  return raw.replace(/[\u201C\u201D]/g, '"');
+}
+
+/**
  * The `/search/:query` segment as text, from the raw param.
  *
  * The router hands this param through RAW -- ask for `/search/%2541` and the


### PR DESCRIPTION
## What broke

A reader types a quoted phrase in the search box — `"食べられない"` — and the search misses, because what reaches the URL is shaped like `"食べられない"` (left/right double curly quotes, U+201C / U+201D) while the corpus carries straight `"`. Auto-correct and copy-paste from most word processors hand over the curly forms by default, so the reader has to retype the same phrase with straight quotes to get the exact-phrase match.

Lucene's `query_string` only recognizes U+0022 as the phrase delimiter. Every other quote character survives as plain text, but only the **double** curly variants represent an exact-phrase intent — they're typographic `"` / `"`, what auto-correct substitutes for `"`. The single and CJK variants are not search syntax; they're literal text the reader typed (often dialogue marks in a subtitle), and the corpus tokenizer already handles them.

This was reported on 2026-09-10 in `#feedback` by `90592`/`funn`:

> e.g. `"食べられない"` and `"食べられない"` should be treated as `"食べられない"` and perform an exact search. I often have to change them manually otherwise because I'm used to other sites normalizing the curly quotes.

## Window and evidence

Sole report so far; telemetry does not surface this — the issue is a wrong-shape outbound query, not a logged error. The fix lives at the input funnel and is verifiable by hand and by unit test.

## Why this fixes it

`InputSegment.vue` is the single submission point for every typed or recalled search: Enter on the box, the magnifying-glass button, the simultaneous-search button, and `runRecent` (which writes the recent's text into the box and then funnels through the same submit). Adding one normalization step at the boundary between `query.value` and the URL it becomes means every one of those paths lands on a URL whose quoted span matches the straight-quoted corpus.

The normalization is a single character class fold — `[\u201C\u201D]` → `"` — and it lives in a `normalizeSearchQuery` helper exported from `routes.ts`, next to `decodeSearchQuery`. Scope is **double** curly quotes only, because that is exactly the shape that means "this is a phrase" in the reader's typing.

## What is deliberately NOT folded

Single curly quotes, angle quotes, CJK corner brackets and the low/high variants are not folded. They are literal text the reader has typed — punctuation the corpus tokenizer already handles — and folding them to `"` would invent an exact-match intent the reader did not have. A reader pasting `"食べられない"` (with `「」`) from a subtitle does not want an exact-phrase search; they want to find sentences containing that dialogue. The corpus tokenizer treats `「」` as punctuation and the search works as expected without any folding at the input side.

## Blast radius

- **Read paths**: nothing. The helper is additive — `decodeSearchQuery` and friends are untouched.
- **Write paths**: only the search submission in `InputSegment.vue`. The URL that ends up in `router.currentRoute` after a search now has straight quotes where the typed text had curly ones — which means the address bar and any link sent from this URL will read straight-quoted, and the recents menu shows straight-quoted. Both of those match what the backend will be searching for, which is the whole point.
- **Non-input call sites of `buildWordSearchPath`** (`ModalBatch.vue`, `pages/stats/words.vue`) build paths from server-supplied words, not reader-typed text, so they are unaffected.
- **Middleware (`server/middleware/search-redirect.ts`)**: not touched. A reader who hand-types a URL containing curly quotes in the path will still get a 301-normalized redirect through the same `overEscapedSearchQuery` logic that already handles it.

## What I did not verify

- **Did not run the e2e suite** (`test:e2e:dev`). Nadeshiko's e2e lives behind a real running stack; running it locally requires the dev backend, Postgres, Elasticsearch, and Shirabe tailnet. The unit tests for `InputSegment.vue`, `routes.ts`, and `server/middleware/search-redirect.ts` all pass.
- **Did not run `socialLinks.sync.test.ts`**. That test failed on my branch — it also fails on `main` without any of my changes; appears to be a Discord-side invite-lookup flake. Worth following up but not blocking this PR.
- **Did not verify in the browser**. A user-visible confirmation requires starting the dev stack and typing a curly-quoted phrase; I confirmed the typed-text → URL transform with the unit tests, but the visual "results now appear" check has not been done.

## Tests

- `frontend/app/utils/routes.test.ts`: 4 new cases under `normalizeSearchQuery` (curly double both sides; asymmetric pair; straight-quoted pass-through; empty string), plus 7 `it.each` rows pinning the single / low-9 / angle / CJK pairs as **not** folded.
- Existing tests in `routes.test.ts`, `InputSegment.test.ts`, and `search-redirect.test.ts` all pass (119 across the three files).

```
$ npx vitest run app/utils/routes.test.ts \
                app/components/search/base/InputSegment.test.ts \
                server/middleware/search-redirect.test.ts

 Test Files  3 passed (3)
      Tests  119 passed (119)
```
